### PR TITLE
fix: Type mismatch between CHAR and UTF8

### DIFF
--- a/shady_ai_flutter/lib/generated/rwkv/rwkv_bindings.g.dart
+++ b/shady_ai_flutter/lib/generated/rwkv/rwkv_bindings.g.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
-import 'package:ffi/ffi.dart';
-
 /// Bindings to rwkv.cpp
 class RWKV {
   /// Holds the symbol lookup function.
@@ -24,7 +22,7 @@ class RWKV {
       : _lookup = lookup;
 
   ffi.Pointer<rwkv_context> rwkv_init_from_file(
-    ffi.Pointer<Utf8> model_file_path,
+    ffi.Pointer<ffi.Char> model_file_path,
     int n_threads,
   ) {
     return _rwkv_init_from_file(
@@ -36,9 +34,9 @@ class RWKV {
   late final _rwkv_init_from_filePtr = _lookup<
       ffi.NativeFunction<
           ffi.Pointer<rwkv_context> Function(
-              ffi.Pointer<Utf8>, ffi.Uint32)>>('rwkv_init_from_file');
-  late final _rwkv_init_from_file = _rwkv_init_from_filePtr
-      .asFunction<ffi.Pointer<rwkv_context> Function(ffi.Pointer<Utf8>, int)>();
+              ffi.Pointer<ffi.Char>, ffi.Uint32)>>('rwkv_init_from_file');
+  late final _rwkv_init_from_file = _rwkv_init_from_filePtr.asFunction<
+      ffi.Pointer<rwkv_context> Function(ffi.Pointer<ffi.Char>, int)>();
 
   bool rwkv_eval(
     ffi.Pointer<rwkv_context> ctx,
@@ -143,11 +141,171 @@ class RWKV {
       .asFunction<ffi.Pointer<ffi.Char> Function()>();
 }
 
+class __mbstate_t extends ffi.Union {
+  @ffi.Array.multi([128])
+  external ffi.Array<ffi.Char> __mbstate8;
+
+  @ffi.LongLong()
+  external int _mbstateL;
+}
+
+class __darwin_pthread_handler_rec extends ffi.Struct {
+  external ffi
+          .Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
+      __routine;
+
+  external ffi.Pointer<ffi.Void> __arg;
+
+  external ffi.Pointer<__darwin_pthread_handler_rec> __next;
+}
+
+class _opaque_pthread_attr_t extends ffi.Struct {
+  @ffi.Long()
+  external int __sig;
+
+  @ffi.Array.multi([56])
+  external ffi.Array<ffi.Char> __opaque;
+}
+
+class _opaque_pthread_cond_t extends ffi.Struct {
+  @ffi.Long()
+  external int __sig;
+
+  @ffi.Array.multi([40])
+  external ffi.Array<ffi.Char> __opaque;
+}
+
+class _opaque_pthread_condattr_t extends ffi.Struct {
+  @ffi.Long()
+  external int __sig;
+
+  @ffi.Array.multi([8])
+  external ffi.Array<ffi.Char> __opaque;
+}
+
+class _opaque_pthread_mutex_t extends ffi.Struct {
+  @ffi.Long()
+  external int __sig;
+
+  @ffi.Array.multi([56])
+  external ffi.Array<ffi.Char> __opaque;
+}
+
+class _opaque_pthread_mutexattr_t extends ffi.Struct {
+  @ffi.Long()
+  external int __sig;
+
+  @ffi.Array.multi([8])
+  external ffi.Array<ffi.Char> __opaque;
+}
+
+class _opaque_pthread_once_t extends ffi.Struct {
+  @ffi.Long()
+  external int __sig;
+
+  @ffi.Array.multi([8])
+  external ffi.Array<ffi.Char> __opaque;
+}
+
+class _opaque_pthread_rwlock_t extends ffi.Struct {
+  @ffi.Long()
+  external int __sig;
+
+  @ffi.Array.multi([192])
+  external ffi.Array<ffi.Char> __opaque;
+}
+
+class _opaque_pthread_rwlockattr_t extends ffi.Struct {
+  @ffi.Long()
+  external int __sig;
+
+  @ffi.Array.multi([16])
+  external ffi.Array<ffi.Char> __opaque;
+}
+
+class _opaque_pthread_t extends ffi.Struct {
+  @ffi.Long()
+  external int __sig;
+
+  external ffi.Pointer<__darwin_pthread_handler_rec> __cleanup_stack;
+
+  @ffi.Array.multi([8176])
+  external ffi.Array<ffi.Char> __opaque;
+}
+
 class rwkv_context extends ffi.Opaque {}
+
+const int __DARWIN_ONLY_64_BIT_INO_T = 1;
+
+const int __DARWIN_ONLY_UNIX_CONFORMANCE = 1;
+
+const int __DARWIN_ONLY_VERS_1050 = 1;
+
+const int __DARWIN_UNIX03 = 1;
+
+const int __DARWIN_64_BIT_INO_T = 1;
+
+const int __DARWIN_VERS_1050 = 1;
+
+const int __DARWIN_NON_CANCELABLE = 0;
+
+const String __DARWIN_SUF_EXTSN = '\$DARWIN_EXTSN';
+
+const int __DARWIN_C_ANSI = 4096;
+
+const int __DARWIN_C_FULL = 900000;
+
+const int __DARWIN_C_LEVEL = 900000;
+
+const int __STDC_WANT_LIB_EXT1__ = 1;
+
+const int __DARWIN_NO_LONG_LONG = 0;
+
+const int _DARWIN_FEATURE_64_BIT_INODE = 1;
+
+const int _DARWIN_FEATURE_ONLY_64_BIT_INODE = 1;
+
+const int _DARWIN_FEATURE_ONLY_VERS_1050 = 1;
+
+const int _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE = 1;
+
+const int _DARWIN_FEATURE_UNIX_CONFORMANCE = 3;
+
+const int __has_ptrcheck = 0;
+
+const int __DARWIN_NULL = 0;
+
+const int __PTHREAD_SIZE__ = 8176;
+
+const int __PTHREAD_ATTR_SIZE__ = 56;
+
+const int __PTHREAD_MUTEXATTR_SIZE__ = 8;
+
+const int __PTHREAD_MUTEX_SIZE__ = 56;
+
+const int __PTHREAD_CONDATTR_SIZE__ = 8;
+
+const int __PTHREAD_COND_SIZE__ = 40;
+
+const int __PTHREAD_ONCE_SIZE__ = 8;
+
+const int __PTHREAD_RWLOCK_SIZE__ = 192;
+
+const int __PTHREAD_RWLOCKATTR_SIZE__ = 16;
+
+const int __DARWIN_WCHAR_MAX = 2147483647;
+
+const int __DARWIN_WCHAR_MIN = -2147483648;
+
+const int __DARWIN_WEOF = -1;
+
+const int _FORTIFY_SOURCE = 2;
 
 const int NULL = 0;
 
 const int USER_ADDR_NULL = 0;
+
+const int __WORDSIZE = 64;
 
 const int INT8_MAX = 127;
 
@@ -252,6 +410,8 @@ const int WINT_MAX = 2147483647;
 const int SIG_ATOMIC_MIN = -2147483648;
 
 const int SIG_ATOMIC_MAX = 2147483647;
+
+const int __bool_true_false_are_defined = 1;
 
 const int true1 = 1;
 

--- a/shady_ai_flutter/lib/main.dart
+++ b/shady_ai_flutter/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:ffi/ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:path/path.dart' as p;
-import 'package:shady_ai/rwkv_bindings.dart';
+import 'package:shady_ai/generated/rwkv/rwkv_bindings.g.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 Future<String> loadModelFile() async {
@@ -91,7 +91,7 @@ class MyHomePageState extends State<MyHomePage> {
     try {
       rwkv = RWKV(await loadLibrwkv());
       final modelFilePath = await loadModelFile();
-      final modelFilePathCStr = modelFilePath.toNativeUtf8();
+      final modelFilePathCStr = modelFilePath.toNativeUtf8().cast<Char>();
       ctx = rwkv.rwkv_init_from_file(modelFilePathCStr, 1);
 
       final state_buffer = rwkv.rwkv_get_state_buffer_element_count(ctx);

--- a/shady_ai_flutter/pubspec.yaml
+++ b/shady_ai_flutter/pubspec.yaml
@@ -57,7 +57,7 @@ dev_dependencies:
 ffigen:
   name: RWKV
   description: Bindings to rwkv.cpp
-  output: 'lib/rwkv_bindings.dart'
+  output: 'lib/generated/rwkv/rwkv_bindings.g.dart'
   headers:
     entry-points:
       - 'headers/rwkv.h'


### PR DESCRIPTION
Previously, I manually edited the generated bindings Dart file because of a type mismatch. 
It's bad practice to edit generated files manually.

Also, I've moved the generated file to a different location.